### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/dev-tools/generate_palette.py
+++ b/dev-tools/generate_palette.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 def download_palette():
-    doc = requests.get('https://minecraft.fandom.com/wiki/Map_item_format')
+    doc = requests.get('https://minecraft.wiki/w/Map_item_format')
     if doc.status_code != 200:
         sys.stderr.write("Couldn't access wiki with status code %d.\n" % doc.status_code)
         return

--- a/helper.py
+++ b/helper.py
@@ -105,7 +105,7 @@ def partition_image_to_map_items(
 
 def create_map(map_color_ids):
     # Begin constructing the NBT file described at
-    # https://minecraft.gamepedia.com/Map_item_format#map_.3C.23.3E.dat_format
+    # https://minecraft.wiki/w/Map_item_format#map_.3C.23.3E.dat_format
     map_color_ids = list(map_color_ids)
 
     nbt_file = NBTFile()


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki